### PR TITLE
Update to 0.7.4 and remove hercules_ci_agent_aws indirection

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -1,0 +1,6 @@
+{ config, lib, pkgs, ... }: {
+  imports = [ <nixpkgs/nixos/modules/virtualisation/amazon-image.nix> ];
+  services.hercules-ci-agent.concurrentTasks = 2; # Number of tasks to run simultaneously
+
+  # Room to configure authentication, logging, monitoring etc if desired.
+}

--- a/extra-configuration.nix
+++ b/extra-configuration.nix
@@ -1,5 +1,0 @@
-{ config, lib, pkgs, ... }: {
-  services.hercules-ci-agent.concurrentTasks = 2; # Number of tasks to run simultaneously
-
-  # Room to configure authentication, logging, monitoring etc as desired.
-}

--- a/main.tf
+++ b/main.tf
@@ -16,23 +16,72 @@ provider "aws" {
   # configure credentials here and in s3 backend above
 }
 
-module "agent-1" {
-  source = "git::https://github.com/hercules-ci/terraform-hercules-ci.git//hercules_ci_agent_aws?ref=6880d40e1a2745096d80d9c5b1c659c0f6b9768c"
+locals {
+  public_key = "~/.ssh/id_rsa.pub"
+  instance_type = "t3.medium"
+  disk_size = 50 # in GiB
+}
+
+module "nixos" {
+  source = "git::https://github.com/hercules-ci/terraform-hercules-ci.git//hercules_ci_agent_nixos?ref=c3c7e2155b7e872cab52460faa86a2fb0cd60375"
+  target_host = aws_instance.machine.public_ip
   use_prebuilt = true
+  configs = [abspath("${path.module}/configuration.nix")]
   cluster_join_token = "${file("${path.module}/cluster-join-token.key")}"
   binary_caches_json = "${file("${path.module}/binary-caches.json")}"
+  NIX_PATH = "nixpkgs=${jsondecode(file("${path.module}/nix/sources.json"))["nixpkgs"]["url"]}"
 
   # This is not a great solution.
   # Also, run `ssh-add ~/.ssh/id_rsa`
-  public_key = "${file("~/.ssh/id_rsa.pub")}"
+  ssh_private_key_file = "~/.ssh/id_rsa"
+  ssh_agent = true
 
-  configs = [
-    abspath("${path.module}/extra-configuration.nix"),
-  ]
+  triggers = {
+    machine_id = aws_instance.machine.id
+    a = 1
+  }
+}
+
+module "nixos_image_1909" {
+  source = "git::https://github.com/hercules-ci/terraform-nixos.git//aws_image_nixos?ref=65fc5758a6660386a02ab32d9e7245cd9a521445"
+  release = "20.03"
+}
+
+resource "aws_security_group" "ssh_and_egress" {
+  ingress {
+    # SSH for deployment
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [ "0.0.0.0/0" ] # TODO: restrict
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_key_pair" "deployer" {
+  key_name   = "deployer-key-${sha256(file(local.public_key))}"
+  public_key = file(local.public_key)
+}
+
+resource "aws_instance" "machine" {
+  ami           = module.nixos_image_1909.ami
+  instance_type = local.instance_type
+  security_groups = [ aws_security_group.ssh_and_egress.name ]
+  key_name = aws_key_pair.deployer.key_name
+  
+  root_block_device {
+    volume_size = local.disk_size # GiB
+  }
 }
 
 output "public_dns" {
-  value = "${module.agent-1.public_dns}"
+  value = aws_instance.machine.public_dns
 }
 
 ################
@@ -61,7 +110,7 @@ resource "aws_dynamodb_table" "terraform_state" {
     type = "S"
   }
 
-  tags {
+  tags = {
     Name = "Terraform Lock Table"
   }
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,14 +1,26 @@
 {
+    "nixpkgs": {
+        "branch": "nixos-20.03",
+        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
+        "homepage": "https://github.com/NixOS/nixpkgs",
+        "owner": "NixOS",
+        "repo": "nixpkgs-channels",
+        "rev": "feff2fa6659799fe7439038b3eba453d62a16e69",
+        "sha256": "0vlnrwlxl6xf6b8rmiy7as2lhi015nklyj2xdiy3ly8xznq69ll9",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs-channels/archive/feff2fa6659799fe7439038b3eba453d62a16e69.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "terraform-hercules-ci": {
         "branch": "master",
         "description": "Terraform modules for Hercules CI",
         "homepage": null,
         "owner": "hercules-ci",
         "repo": "terraform-hercules-ci",
-        "rev": "6880d40e1a2745096d80d9c5b1c659c0f6b9768c",
-        "sha256": "14q1f7f9kih6hvykybncxzwqkdhmlmxf57n19hscyrxxvmfzzm99",
+        "rev": "c3c7e2155b7e872cab52460faa86a2fb0cd60375",
+        "sha256": "0929fpdc9ppr4wfzdry3n0cispxqkdjbrw5fz8m0gbni435hj0md",
         "type": "tarball",
-        "url": "https://github.com/hercules-ci/terraform-hercules-ci/archive/6880d40e1a2745096d80d9c5b1c659c0f6b9768c.tar.gz",
+        "url": "https://github.com/hercules-ci/terraform-hercules-ci/archive/c3c7e2155b7e872cab52460faa86a2fb0cd60375.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
That module was only suitable for simple examples and switching
away from it is work.
Removing the indirection makes this example easier to adapt.